### PR TITLE
Fix for cleantable perl code & Link List

### DIFF
--- a/51)Cleanup Table.kmmacros
+++ b/51)Cleanup Table.kmmacros
@@ -16,7 +16,7 @@
 						<key>IsActive</key>
 						<true/>
 						<key>IsDisclosed</key>
-						<false/>
+						<true/>
 						<key>KeyCode</key>
 						<integer>7</integer>
 						<key>MacroActionType</key>
@@ -25,6 +25,18 @@
 						<integer>256</integer>
 						<key>ReleaseAll</key>
 						<false/>
+					</dict>
+					<dict>
+						<key>IsActive</key>
+						<true/>
+						<key>IsDisclosed</key>
+						<true/>
+						<key>MacroActionType</key>
+						<string>SetVariableToText</string>
+						<key>Text</key>
+						<string>%CurrentClipboard%</string>
+						<key>Variable</key>
+						<string>MMD__Table</string>
 					</dict>
 					<dict>
 						<key>IsActive</key>
@@ -44,7 +56,7 @@
 						<key>IsActive</key>
 						<true/>
 						<key>IsDisclosed</key>
-						<false/>
+						<true/>
 						<key>MacroActionType</key>
 						<string>ExecuteShellScript</string>
 						<key>Path</key>
@@ -67,7 +79,7 @@
 use utf8;
 
 local $/;
-$text = &lt;&gt;;
+$text = $ENV{"KMVAR_MMD__Table"};
 }
 
 my %max_width = ();
@@ -429,7 +441,7 @@ sub setWidth {
 						<key>IsActive</key>
 						<true/>
 						<key>IsDisclosed</key>
-						<false/>
+						<true/>
 						<key>MacroActionType</key>
 						<string>DeletePastClipboard</string>
 						<key>PastExpression</key>
@@ -439,7 +451,7 @@ sub setWidth {
 						<key>IsActive</key>
 						<true/>
 						<key>IsDisclosed</key>
-						<false/>
+						<true/>
 						<key>MacroActionType</key>
 						<string>DeletePastClipboard</string>
 						<key>PastExpression</key>
@@ -744,7 +756,7 @@ sub setWidth {
 				<key>IsActive</key>
 				<true/>
 				<key>ModificationDate</key>
-				<real>395959095.99225402</real>
+				<real>411441313.73767197</real>
 				<key>Name</key>
 				<string>51)Cleanup Table</string>
 				<key>Triggers</key>
@@ -755,7 +767,7 @@ sub setWidth {
 					</dict>
 				</array>
 				<key>UID</key>
-				<string>406D2819-94AB-475F-BDB2-149F395F77CE</string>
+				<string>A6EE15AC-F23C-4F44-98A2-F8B25170EB0E</string>
 			</dict>
 		</array>
 		<key>Name</key>

--- a/51)Cleanup Table.kmmacros
+++ b/51)Cleanup Table.kmmacros
@@ -56,7 +56,7 @@
 						<key>IsActive</key>
 						<true/>
 						<key>IsDisclosed</key>
-						<true/>
+						<false/>
 						<key>MacroActionType</key>
 						<string>ExecuteShellScript</string>
 						<key>Path</key>
@@ -441,7 +441,7 @@ sub setWidth {
 						<key>IsActive</key>
 						<true/>
 						<key>IsDisclosed</key>
-						<true/>
+						<false/>
 						<key>MacroActionType</key>
 						<string>DeletePastClipboard</string>
 						<key>PastExpression</key>
@@ -451,7 +451,7 @@ sub setWidth {
 						<key>IsActive</key>
 						<true/>
 						<key>IsDisclosed</key>
-						<true/>
+						<false/>
 						<key>MacroActionType</key>
 						<string>DeletePastClipboard</string>
 						<key>PastExpression</key>
@@ -756,7 +756,7 @@ sub setWidth {
 				<key>IsActive</key>
 				<true/>
 				<key>ModificationDate</key>
-				<real>411441313.73767197</real>
+				<real>411441545.66995502</real>
 				<key>Name</key>
 				<string>51)Cleanup Table</string>
 				<key>Triggers</key>

--- a/51)Cleanup Table.kmmacros
+++ b/51)Cleanup Table.kmmacros
@@ -16,7 +16,7 @@
 						<key>IsActive</key>
 						<true/>
 						<key>IsDisclosed</key>
-						<true/>
+						<false/>
 						<key>KeyCode</key>
 						<integer>7</integer>
 						<key>MacroActionType</key>
@@ -30,7 +30,7 @@
 						<key>IsActive</key>
 						<true/>
 						<key>IsDisclosed</key>
-						<true/>
+						<false/>
 						<key>MacroActionType</key>
 						<string>SetVariableToText</string>
 						<key>Text</key>
@@ -756,7 +756,7 @@ sub setWidth {
 				<key>IsActive</key>
 				<true/>
 				<key>ModificationDate</key>
-				<real>411441545.66995502</real>
+				<real>411441647.13116598</real>
 				<key>Name</key>
 				<string>51)Cleanup Table</string>
 				<key>Triggers</key>

--- a/Markdown Link/2 Link List from Clipboard.kmmacros
+++ b/Markdown Link/2 Link List from Clipboard.kmmacros
@@ -58,9 +58,13 @@
 						<key>Path</key>
 						<string></string>
 						<key>Text</key>
-						<string>#!/usr/bin/env ruby -rjcode -Ku
+						<string>#!/usr/bin/env ruby -Ku
 
-$KCODE = 'u'
+if RUBY_VERSION.to_f &gt; 1.9
+	Encoding.default_external = Encoding::UTF_8
+	Encoding.default_internal = Encoding::UTF_8
+end
+
 UNICODE_COMPETENT = ((RUBY_VERSION)[0..2].to_f &gt; 1.8)
 
 unless UNICODE_COMPETENT # lower than 1.9
@@ -78,8 +82,8 @@ else # 1.9 and above
 end
 
 def clipboard_to_references(input)
-  links = input.scan /(?:\[([^\]]+)\]\: )?(https?:\/\/[^ \n"]+)/m
-
+  # links = input.scan /(?:\[([^\]]+)\]\: )?(https?:\/\/[^ \n"&gt;\)]+)/m
+  links = input.scan(/(?:\[([^\]]+)\]\: )?(https?:\/\/([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w&amp;\?=.-]*)*\/?)/im)
   if links.empty? &amp;&amp; input.empty?
   	exit
   else
@@ -95,8 +99,10 @@ def clipboard_to_references(input)
     		  domain = url[1].match(/https?:\/\/([^\/]+)/)
     		  parts = domain[1].split('.')
     		  name = case parts.length
-    			  when 1: parts[0]
-    			  when 2: parts[0]
+    			  when 1
+					parts[0]
+    			  when 2
+					parts[0]
     			  else parts[1]
     		  end
     		end
@@ -114,18 +120,18 @@ def clipboard_to_references(input)
     	output &lt;&lt; {'title' =&gt; name, 'link' =&gt; url[1] }
     	norepeat.push name
     }
-    output = output.sort {|a,b| a['title'] &lt;=&gt; b['title']}
-    counter = 0
-    output.each { |x| 
-    	counter += 1
-    	puts "[#{x['title']}]: #{x['link']}"
-    }
+    output.sort! {|a,b| a['title'] &lt;=&gt; b['title']}
+	output
   end
 end
 
 pboard = %x{__CF_USER_TEXT_ENCODING=$UID:0x8000100:0x8000100 pbpaste}.strip
-clipboard_to_references(pboard)
-</string>
+output = clipboard_to_references(pboard)
+counter = 0
+output.each { |x| 
+  counter += 1
+  puts "[#{x['title']}]: #{x['link']}"
+}</string>
 						<key>TimeOutAbortsMacro</key>
 						<true/>
 						<key>TrimResults</key>
@@ -509,7 +515,7 @@ clipboard_to_references(pboard)
 				<key>IsActive</key>
 				<true/>
 				<key>ModificationDate</key>
-				<real>396101726.03137302</real>
+				<real>411443031.63071901</real>
 				<key>Name</key>
 				<string>2: Link List from Clipboard</string>
 				<key>Triggers</key>
@@ -530,7 +536,7 @@ clipboard_to_references(pboard)
 					</dict>
 				</array>
 				<key>UID</key>
-				<string>CACEDEAD-88E0-47AD-90B0-E2B30DA41FD3</string>
+				<string>0E47DAC6-4176-4EFF-9EF4-4A245A60D62D</string>
 			</dict>
 		</array>
 		<key>Modifiers</key>


### PR DESCRIPTION
This fixes the Clean Table macro by 1) storing the selection to a new variable `MMD__Table` and then using that in the perl script instead of stdin.

I also updated the Clipboard Link List code to the current version from Brett Terpstra's library, where it originated, which takes care of the issues with Ruby > 1.9 and has some other fixes besides. It works great.

There are multiple commits because a) I just figured out how to do this,  b) I forgot to close all the descriptions before exporting, creating unnecessary changes, and c) I didn't know I had to create branches to create separate pull requests for each file/macro. Hopefully this is useful anyway.
